### PR TITLE
New workflow for automatic TEI in pull request

### DIFF
--- a/.github/workflows/transform.yml
+++ b/.github/workflows/transform.yml
@@ -1,19 +1,16 @@
 name: Transform
 
-on: 
-  push:
-      branches-ignore:
-        - 'main'
+on: [pull_request]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - name: checkout repo content
         uses: actions/checkout@v2
         with: 
           ref: ${{ github.ref }}
+          fetch-depth: 0
       - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -22,11 +19,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install networkx lxml
-      - id: files
-        uses: jitterbit/get-changed-files@v1
-      - name: Run transformation
+      - name: Convert files
         run: |
-          for changed_file in ${{ steps.files.outputs.added_modified }}; do
+          files=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{github.event.pull_request.head.sha}})
+          for changed_file in $files; do
             if [ "${changed_file: -9}" == "stemma.gv" ] || [ "${changed_file: -12}" == "metadata.txt" ] ; 
               then echo "Converting ${changed_file}."
               python ./transform/transformation.py ${changed_file} ; 


### PR DESCRIPTION
It worked in my test repo :smiley: 

It creates an extra commit with the automatic conversion when one does the pull request, before merging. Each time a new commit is made to the branch of the pull request, the action is lauched again. So by the time the pull request is approved the TEI and graphml are already created.